### PR TITLE
Fix invalid this reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var tryRequire = function tryRequire(id, req) {
     try {
         path = _req.resolve(id);
     } catch (e) {
-        this.error = e;
+        module.exports.error = e;
     }
 
     if (path) {
@@ -24,7 +24,7 @@ var resolve = function tryRequireResolve(id, req) {
     try {
         path = _req.resolve(id);
     } catch (e) {
-        this.error = e;
+        module.exports.error = e;
     }
 
     return path;


### PR DESCRIPTION
Setting the error on `this` does not have the desired effect, as `this` isn't bound in the normal use-case (which I neglected to take into account in my original patch).
